### PR TITLE
Vertically Center profile picture with the About section. 

### DIFF
--- a/_includes/about/about.html
+++ b/_includes/about/about.html
@@ -1,7 +1,7 @@
 <div style="background-color: var(--tf-page-bg-color)" class="bg-gradient py-3">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4">
+      <div class="col-lg-4 d-flex align-items-center justify-content-center">
         <img width="300px" src="{{ site.data.bio.basics.picture }}" class="d-block mx-auto rounded-circle">
       </div>
       <div class="col-lg-8">


### PR DESCRIPTION
This pull request makes a small adjustment to the layout of the "About" section in the `_includes/about/about.html` file. The change ensures that the image container is centered both vertically and horizontally.

* [`_includes/about/about.html`](diffhunk://#diff-77362abcc1e68cc10882bcda51e1e1a98acd4bd1db0e6db704f54c5674f6d724L4-R4): Added `d-flex align-items-center justify-content-center` classes to the `div` wrapping the image, centering it within its column.